### PR TITLE
Added AJP support using sysprop tomcat.protocol.ajp

### DIFF
--- a/src/main/java/com/sphereon/ms/did/mapping/config/ServletContainer.java
+++ b/src/main/java/com/sphereon/ms/did/mapping/config/ServletContainer.java
@@ -1,0 +1,25 @@
+package com.sphereon.ms.did.mapping.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(
+        value = "tomcat.protocol.ajp",
+        havingValue = "true"
+)
+public class ServletContainer {
+
+    @Bean
+    public EmbeddedServletContainerCustomizer servletContainerCustomizer() {
+        return container -> {
+            if (container instanceof TomcatEmbeddedServletContainerFactory) {
+                ((TomcatEmbeddedServletContainerFactory) container)
+                        .setProtocol("AJP/1.3");
+            }
+        };
+    }
+}


### PR DESCRIPTION
* This was an older PR which I assigned to Scott because he was the author, but he never replied *

To activate this functionality the start script needs to specify the following properties:
`-Dtomcat.protocol.ajp=true -Dserver.port=8009`

This will enable support in Apache for ajp mappings:
        ProxyPass / ajp://127.0.0.1:8009/
        ProxyPassReverse / ajp://127.0.0.1:8009/
This will bypass Tomcat's embedded HTTP service. (Apache becomes the HTTP front-end and will pass on the already parsed request in binary format to Tomcat using a plain socket connection pool)